### PR TITLE
Output a valid JSON array for CVE feed

### DIFF
--- a/csv-builder.py
+++ b/csv-builder.py
@@ -68,4 +68,4 @@ filtered_json = df_filled[df_filled['state'] == 'published']
 json_file_path = 'published_output.json'
 
 # Write DataFrame to JSON file for published incidents
-filtered_json.to_json(json_file_path, orient='records', lines=True)
+filtered_json.to_json(json_file_path, orient='records')


### PR DESCRIPTION
The generated JSON right now has lines of separate JSON objects: each line can be parsed as a separate JSON, but not all of them together. This changes the output to a single JSON array, which makes parsing the file easier.