### PR TITLE
initial draft of security contact list

### DIFF
--- a/docs/contact-list.md
+++ b/docs/contact-list.md
@@ -1,0 +1,28 @@
+# Security Contact List
+
+Beyond the initial fix team, a mailing list is setup to include additional
+organizations that can benefit from early CVE access. This mailing list
+is created per repository
+
+## OpenTelemetry Collector Distro Security Contacts List
+
+Currently on the opentelemetry-collector-distros list are representatives from:
+
+*
+*
+
+## Membership Criteria
+
+To be eligible for (opentelemetry-)distros list membership, your distro should:
+
+* Be an actively maintained Open Source OpenTelemetry distribution
+* Have a userbase not limited to your own organization
+* Have a publicly verifiable track record, dating back at least 1 year and
+  continuing to present day, of fixing security issues and releasing the 
+  fixes within 10 days of the issues being made public
+* Not be downstream or a rebuild of another distro
+* Be a participant and preferably an active contributor in relevant public
+  communities
+* Be able and willing to contribute back, preferably in specific ways announced
+  in advance, and demonstrate actual contributions once you've been a member
+  for a while

--- a/docs/contact-list.md
+++ b/docs/contact-list.md
@@ -2,7 +2,7 @@
 
 Beyond the initial fix team, a mailing list is setup to include additional
 organizations that can benefit from early CVE access. This mailing list
-is created per repository
+is created per repository.
 
 ## OpenTelemetry Collector Distro Security Contacts List
 
@@ -16,7 +16,7 @@ Currently on the opentelemetry-collector-distros list are representatives from:
 To be eligible for (opentelemetry-)distros list membership, your distro should:
 
 * Be an actively maintained Open Source OpenTelemetry distribution
-* Have a userbase not limited to your own organization
+* Have a user base not limited to your own organization
 * Have a publicly verifiable track record, dating back at least 1 year and
   continuing to present day, of fixing security issues and releasing the 
   fixes within 10 days of the issues being made public

--- a/docs/contact-list.md
+++ b/docs/contact-list.md
@@ -13,7 +13,8 @@ Currently on the opentelemetry-collector-distros list are representatives from:
 
 ## Membership Criteria
 
-To be eligible for (opentelemetry-)distros list membership, your distro should:
+The membership is initially decided by sig-security members. To be eligible
+for (opentelemetry-)distros list membership, your distro should:
 
 * Be an actively maintained Open Source OpenTelemetry distribution
 * Have a user base not limited to your own organization

--- a/security-response.md
+++ b/security-response.md
@@ -86,6 +86,8 @@ that the report is accepted as valid.
   [CVSS Calculator](https://www.first.org/cvss/calculator/3.1) and ping the TC
   GitHub team for confirmation.
 - The Fix Team will request a CVE from GitHub and follow up with the reporter.
+- The Fix Team will report the CVE to the [security contact list](./docs/contact-list.md) 
+  if applicable.
 - The Fix Team publishes the CVE to the GitHub Security Advisory Database for
   user notification.
 


### PR DESCRIPTION
This is an initial draft with the idea that the first mailing list will be specific to the otel collector. The criteria is very similar to the linux distro criteria https://oss-security.openwall.org/wiki/mailing-lists/distros#membership-criteria

Fixes #61