### PR TITLE
Add Jeremy Corley as a project lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ of the Security Special Interest Group.
 
 ## Project Leadership
 
+* [Jeremy Corley](https://github.com/ms-jcorley), Microsoft
 * [Reiley Yang](https://github.com/reyang), Microsoft
 
 ## Emeritus


### PR DESCRIPTION
I am adding @ms-jcorley as a project lead here to drive the project together with me - after the departure of other members (e.g. #76, #78).

@ms-jcorley is helping the SIG Security to define the policy and procedures (we've [met the TC couple times](https://docs.google.com/document/d/1hOHPCu5TGenqTeWPB9qQB_qd33uITZBcvK1FnWxYJAw/edit?tab=t.0#heading=h.cixa1o9hv5bz), there is an initial proposal which folks are still discussing, #84 captured some thoughts, etc.).