### PR TITLE
Document enabling Private vulnerability reporting

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -1,0 +1,9 @@
+# Repository settings
+
+This document describes any changes that have been made to the
+settings for this repository beyond the [OpenTelemetry default repository
+settings](../docs/how-to-configure-new-repository.md#repository-settings).
+
+## Advanced Security
+
+* Private vulnerability reporting = Enabled


### PR DESCRIPTION
Documenting the settings change per the instructions here:
https://github.com/open-telemetry/community/blob/c25a0b0f0a7e87e79cfbd7aa5bda92ad22832a6c/docs/how-to-configure-new-repository.md#collaborators-and-teams--manage-access

Turned on Private vulnerability reporting in this repo for two reasons:
1.  Some external reporters may expect to find the "Report a vulnerability" button on this repo and we want reporting to be as easy to find as possible.  Any/all external reports here will be redirected to the correct repo.
2.  Security SIG members can use their access here to test / screen shot / document the Vulnerability Management process under the real conditions of an OTEL managed repo.
