### PR TITLE
Improve Documentation for Vulnerability Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ of the Security Special Interest Group.
 
 ## Meetings
 
-* Regular SIG Meeting: Weekly on Mondays at [16:00
-  UTC](https://dateful.com/convert/utc?t=16).
+* Regular SIG Meeting: Weekly on Mondays at [09:00
+PT](https://dateful.com/convert/pst-pdt-pacific-time?t=0900).
   * [Meeting notes, Agenda and Zoom
   link](https://docs.google.com/document/d/1P2xejC7lEkOV_Z-8E0oZPXLK5HOnUPNuRqKP0ZQ5fpg).
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ of the Security Special Interest Group.
 
 ## Meetings
 
-* Regular SIG Meeting: Bi-weekly on Wednesdays at [14:00
-  UTC](https://dateful.com/convert/utc?t=14).
-  * [Meeting notes and
-    Agenda](https://docs.google.com/document/d/1P2xejC7lEkOV_Z-8E0oZPXLK5HOnUPNuRqKP0ZQ5fpg).
+* Regular SIG Meeting: Weekly on Mondays at [16:00
+  UTC](https://dateful.com/convert/utc?t=16).
+  * [Meeting notes, Agenda and Zoom
+  link](https://docs.google.com/document/d/1P2xejC7lEkOV_Z-8E0oZPXLK5HOnUPNuRqKP0ZQ5fpg).
 
 ## Project Leadership
 

--- a/security-response.md
+++ b/security-response.md
@@ -4,10 +4,9 @@ Security vulnerabilities should be handled quickly and sometimes privately. The
 primary goal of this process is to reduce the total time users are vulnerable to
 publicly known exploits.
 
-The OpenTelemetry Technical Committee (OTel TC) and relevant repository
-maintainers, supported by tooling provided by the SIG-Security, are responsible
-for responding to the incident organizing the entire response including internal
-communication and external disclosure.
+The relevant OTEL repository maintainers, supported by the SIG-Security and
+OpenTelemetry Technical Committee (OTel TC), are responsible for responding to
+the incident including internal communication and external disclosure.
 
 ## Supported Versions
 
@@ -23,38 +22,53 @@ be released. Each repository is entitled to establish their own complementary
 processes. SIG-Security in conjunction with the TC can advise in case
 clarifications are required.  
 
-## Disclosures
+## Reporting Process - For Vulnerability Reporters
 
-### Private Disclosure Processes
+### Reporting Methods
 
 In order for the vulnerability reports to reach maintainers as soon as possible,
 the preferred way is to use the `Report a vulnerability` button on the
 `Security` tab in the respective GitHub repository. It creates a private
 communication channel between the reporter and the maintainers.
 
-If you are absolutely unable to or have strong reasons not to use GitHub
+If you are unable to or have strong reasons not to use the GitHub
 reporting workflow, please reach out to the Technical Committee using
 [cncf-opentelemetry-tc@lists.cncf.io](mailto:cncf-opentelemetry-tc@lists.cncf.io)
 and we will provide instruction on how to report the vulnerability using an
-encrypted message, if desired.
+encrypted message, if desired.  The TC should receive the message and re-direct
+it to the relevant repository maintainers for ownership.
 
-### Public Disclosure Processes
+Reports should be acknowledged within 3 working days.
 
-If you know of a publicly disclosed security vulnerability please IMMEDIATELY
-email
-[cncf-opentelemetry-tc@lists.cncf.io](mailto:cncf-opentelemetry-tc@lists.cncf.io)
-to inform the Security Response Committee (SRC) about the vulnerability so they
-may start the patch, release, and communication process. Please include any
-relevant information about current public exploitations of this vulnerability if
-known to help with scoring and prioritization.
+**Please avoid reporting any vulnerabilities as a generic public "Issue" in
+GitHub.**
 
-The TC should receive the message and re-direct it to the relevant repository
-maintainers for ownership. If possible the repository maintainers will engage
-and ask the person making the public report if the issue can be handled via a
-private disclosure process. If the reporter denies the request, the repository
-maintainers will move swiftly with the fix and release process. In extreme cases
-you can ask GitHub to delete the issue but this generally isn't necessary and is
-unlikely to make a public disclosure less damaging.
+Given the public visibility of GitHub issues, reporting a vulnerability as a
+GitHub issue would be public disclosure. If this is done accidentally or if you
+notice a vulnerability reported this way, please immediately re-report the
+vulnerability using "Report a vulnerability" and note the public disclosure as
+part of that report.  You can ask GitHub to delete the issue but this shouldn't
+be considered a sufficient mitigation and the vulnerability should be considered
+publicly disclosed.
+
+### Non-Public Vulnerabilities
+
+If a vulnerability appears to be not publicly known or disclosed, the repository
+maintainers will engage and the reporter is requested to honor an embargo period
+in which the vulnerability is keep private until a fix can be released and
+disclosed in an orderly manner.  If the reporter has a need to disclose the
+vulnerability further, perhaps for a security conference or other obligation,
+they are asked to negotiate the disclosure date with the maintainers fixing the
+vulnerability. The repository maintainers will in any case do their best to move
+swiftly with the fix and release process.
+
+### Publicly Known Vulnerabilities
+
+If you discover an unreported publicly disclosed/known vulnerability please
+IMMEDIATELY use the reporting methods above to inform the team about the
+vulnerability so they may start the patch, release and communication process.
+Please include any relevant information about current public exploitations of
+this vulnerability, if known, to help with scoring and prioritization.
 
 ## Patch, Release, and Public Communication
 

--- a/security-response.md
+++ b/security-response.md
@@ -4,7 +4,7 @@ Security vulnerabilities should be handled quickly and sometimes privately. The
 primary goal of this process is to reduce the total time users are vulnerable to
 publicly known exploits.
 
-The relevant OTEL repository maintainers, supported by the SIG-Security and
+The relevant OTel repository maintainers, supported by the Security SIG and
 OpenTelemetry Technical Committee (OTel TC), are responsible for responding to
 the incident including internal communication and external disclosure.
 
@@ -20,7 +20,7 @@ branch at the moment of the release. For instance, if the latest version is
 Security fixes are given priority and might be enough to cause a new version to
 be released. Each repository is entitled to establish their own complementary
 processes. SIG-Security in conjunction with the TC can advise in case
-clarifications are required.  
+clarifications are required.
 
 ## Reporting Process - For Vulnerability Reporters
 
@@ -35,7 +35,7 @@ If you are unable to or have strong reasons not to use the GitHub
 reporting workflow, please reach out to the Technical Committee using
 [cncf-opentelemetry-tc@lists.cncf.io](mailto:cncf-opentelemetry-tc@lists.cncf.io)
 and we will provide instruction on how to report the vulnerability using an
-encrypted message, if desired.  The TC should receive the message and re-direct
+encrypted message, if desired. The TC should receive the message and re-direct
 it to the relevant repository maintainers for ownership.
 
 Reports should be acknowledged within 3 working days.
@@ -47,7 +47,7 @@ Given the public visibility of GitHub issues, reporting a vulnerability as a
 GitHub issue would be public disclosure. If this is done accidentally or if you
 notice a vulnerability reported this way, please immediately re-report the
 vulnerability using "Report a vulnerability" and note the public disclosure as
-part of that report.  You can ask GitHub to delete the issue but this shouldn't
+part of that report. You can ask GitHub to delete the issue but this shouldn't
 be considered a sufficient mitigation and the vulnerability should be considered
 publicly disclosed.
 
@@ -56,7 +56,7 @@ publicly disclosed.
 If a vulnerability appears to be not publicly known or disclosed, the repository
 maintainers will engage and the reporter is requested to honor an embargo period
 in which the vulnerability is keep private until a fix can be released and
-disclosed in an orderly manner.  If the reporter has a need to disclose the
+disclosed in an orderly manner. If the reporter has a need to disclose the
 vulnerability further, perhaps for a security conference or other obligation,
 they are asked to negotiate the disclosure date with the maintainers fixing the
 vulnerability. The repository maintainers will in any case do their best to move

--- a/sig-security-charter.md
+++ b/sig-security-charter.md
@@ -12,9 +12,7 @@ This includes:
 * improving the vulnerability management process
 * producing cross-cutting security documentation
 * serving as a security community touch point
-* managing the non-embargoed (public) vulnerability process
-* default repo configurations
-* defining the bug bounty
+* default repo configurations related to security
 
 As a process-oriented SIG, SIG Security does not directly own OpenTelemetry
 component code.
@@ -26,10 +24,9 @@ component code.
 Work with the OpenTelemetry Technical Committee (TC) to define the processes for
 fixing and disclosing vulnerabilities. For example:
 
-* The default level for OTel repo GitHub security configuration and tooling
+* The default OTel repo GitHub security configuration and tooling
 * When the private fix & release process is invoked
 * How vulnerabilities are rated
-* The scope of the bug bounty
 * Post-announcement follow-ups, such as additional fixes, mitigations,
   preventions or documentation after a vulnerability is made public
 * Distributor announcement policies, such as timelines, criteria for joining the
@@ -81,8 +78,4 @@ SIG Security’s scope does not include:
 * Vendor or distribution specific guidelines and vulnerability coverage
 * Recommendations or endorsements of specific commercial product vendors or
   cloud providers
-* Private vulnerability response (belongs to the relevant repo owners),
-  including:
-  * Embargoed vulnerability management
-  * Bug bounty submission triage and management
-  * Non-public vulnerability collection, triage, and disclosure
+* Direct vulnerability response, this belongs to the relevant repo owners.


### PR DESCRIPTION
1. Fix the time/date of the Security SIG meeting in the README
2. Remove mentions of a bug bounty since we don't have one
3. Refactor the description of the Reporting process and target it specifically to vuln Reporters
4. Fixed other small nits

Coming soon:
Refactoring the other half of security-response.md for Maintainers to make it clear how we recommend they handle incoming vulns.  I might consider breaking this into two files.
