### PR TITLE
Adriel Perkins as Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ PT](https://dateful.com/convert/pst-pdt-pacific-time?t=0900).
 [@open-telemetry/sig-security-approvers](
   https://github.com/orgs/open-telemetry/teams/sig-security-approvers)
 
-* None currently, Please come get involved if you are interested!
+* [Adriel Perkins](https://github.com/adrielp), Liatrio
 
 ## Emeritus
 


### PR DESCRIPTION
I nominate Adriel Perkins (@adrielp) as an Approver.
His security background and contributions to OTel and this SIG make him a great fit.

Adriel, if you accept, please also approve.

@open-telemetry/sig-security-maintainers 
