### PR TITLE
Fix CODEOWNERS to correct alias - approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/sig-security-maintainers
+* @open-telemetry/sig-security-approvers


### PR DESCRIPTION
Updating the CODEOWNERS file to correct the alias, i.e. sig-security-approvers.
