### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "docker:pinDigests",
+    "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "packageRules": [


### PR DESCRIPTION
It seems `best-practices` is a good replacement for `recommended`, see https://docs.renovatebot.com/upgrade-best-practices/.