### PR TITLE
Increase stale issue time before close

### DIFF
--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue was marked stale due to lack of activity and will be closed in 7 days. Commenting will instruct the bot to automatically remove the label. This bot runs once per day.'
+          stale-issue-message: 'This issue was marked stale due to lack of activity and will be closed in 30 days. Commenting will instruct the bot to automatically remove the label. This bot runs once per day.'
           close-issue-message: 'Closed as inactive. Feel free to reopen if this issue is still a concern.'
           stale-pr-message: 'This PR was marked stale due to lack of activity and will be closed in 7 days. Commenting or pushing will instruct the bot to automatically remove the label. This bot runs once per day.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
@@ -24,4 +24,4 @@ jobs:
           days-before-pr-stale: 7
           days-before-issue-stale: 360
           days-before-pr-close: 7
-          days-before-issue-close: 7
+          days-before-issue-close: 30


### PR DESCRIPTION
After waiting 360 days to mark an issue as stale, let's give 30 days before auto closing it.