### PR TITLE
Rewrite - Vulnerability Management for Maintainers

### DIFF
--- a/security-response.md
+++ b/security-response.md
@@ -70,76 +70,248 @@ vulnerability so they may start the patch, release and communication process.
 Please include any relevant information about current public exploitations of
 this vulnerability, if known, to help with scoring and prioritization.
 
-## Patch, Release, and Public Communication
+## Vulnerability Management - For Maintainers
 
-### Fix Team Organization
+Maintainers of OTel projects have the role of being the primary responders
+and managers of vulnerabilities reported in their respective repos.
 
-The Fix Team is made up of the relevant repository maintainers and a Fix Lead is
-responsible for ensuring the successful execution of the incident response.
+Maintainers should familiarize themselves with the above guidance for Reporters
+and encourage any potential Reporters to follow that guidance.
 
-### TC Role
+### GitHub Tooling
 
-- Assign a Fix Lead, typically a code owner or maintainer for the affected code
-- A member of the TC will need to review the proposed CVSS score and severity
-  from the Fix Team
-- Acknowledge when a proposed fix is completed
+Vulnerabilities reported via the `Report a vulnerability` button will appear
+for Maintainers as a Security Advisory under the `Security` tab under
+the `Advisories` side bar option.
 
-### Fix Development Process
+Maintainers can also create their own draft Security Advisory here using the
+`New draft security advisory` button if they discover an unreported issue or
+need to report for someone who is unwilling or unable to use the
+`Report a vulnerability` button.
 
-All of the timelines below are suggestions that assume a Private Disclosure and
-that the report is accepted as valid.
+Note that for a specific OTel repo, only that repo's Maintainers and Security
+SIG Maintainers (which have been granted the Security Manager role) will have
+access to the full Advisories data and functionality.
 
-#### Initial Incident Response
+For more detailed GitHub documentation on this feature, see
+[this link](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories)
 
-- The TC is notified of an incident and the relevant repository maintainers are
-  added automatically using a Zapier workflow as the Fix Team to the issue.
-- The Fix Team acknowledges the incident to the reporter, asks for further
-  details if necessary, and begins mitigation planning.
-- The Fix Team confirms with the reporter if the incident is valid and requires
-  a fix.
-- The Fix Team creates a temporary Slack channel and private branch to start
-  work on the fix.
-- The Fix Team will create a
-  [CVSS](https://www.first.org/cvss/specification-document) Base score using the
-  [CVSS Calculator](https://www.first.org/cvss/calculator/3.1) and ping the TC
-  GitHub team for confirmation.
-- The Fix Team will request a CVE from GitHub and follow up with the reporter.
-- The Fix Team will report the CVE to the [security contact
-  list](./docs/contact-list.md) if applicable.
-- The Fix Team publishes the CVE to the GitHub Security Advisory Database for
-  user notification.
+### Incident Response
 
-#### Incident Mitigation
+Vulnerability reports should be acknowledged by Maintainers within 3 working
+days. This acknowledgment should include a brief confirmation that the report
+has been received and that Maintainers are evaluating the issue.
 
-The incident mitigation timeline depends on the severity of the incident and
-repository release cadence.
+When processing a vulnerability report, Maintainers should:
 
-- The Fix Team will ping the TC GitHub team to alert them that work on the fix
-  branch is complete once there are LGTMs on all commits in the temporary
-  private fork created for the GitHub Security Advisory.
-- The updated version is released with the fix.
-- The incident is published to the GitHub Security Advisory Database and
-  affected users are automatically notified using GitHub security alerts.
+1. Acknowledge receipt of the report within 3 working days
+1. Invite Collaborators as needed
+1. Verify if the reported issue is actually a vulnerability
+1. Assess the severity and impact of the vulnerability
+1. Determine if the vulnerability is already publicly known or disclosed
+1. Negotiate an embargo period, if needed
+1. Request a CVE, if needed
+1. Create a Temporary Private Fork, if needed
+1. Ensure work is progressing on a resolution in accordance with severity and
+  embargo timeline
+1. When a fix is ready, Publish the Advisory
 
-### Fix Disclosure Process
+### Managing Collaborators
 
-OTel relies on GitHub tooling to notify the affected repositories and publish a
-security advisory. GitHub will publish the CVE to the CVE List, broadcast the
-Security Advisory via the GitHub Advisory Database, and send security alerts to
-all repositories that use the package and have alerts on. The CVE will also be
-added to the [OTel website's CVE
-feed](https://opentelemetry.io/docs/security/cve/).
+When working on security advisories in GitHub:
 
-#### Fix Release Day
+1. Maintainers can add Collaborators to assist with investigation and fixing by
+   using the "Add users or teams" edit box in the Collaborators section in the
+   GitHub Security Advisory interface.
+2. Try to keep the number of Collaborators small to limit the exposure of the
+    vulnerability details before a fix is available.
+3. Only add Collaborators who are necessary for investigating or fixing the
+    issue.
+4. Consider adding Collaborators who:
+   - Understand the affected code
+   - Can assist with implementing or reviewing fixes
+   - Have expertise in the specific security domain
 
-The Fix Team as repository owners will release an updated version and optionally
-notify their communities via Slack.
+### Using Temporary Private Forks
 
-## Severity
+GitHub provides temporary private forks as a secure environment to fix
+vulnerabilities without exposing them to the public. These forks allow you to
+collaborate with others on fixing security issues before making the fixes
+public.
 
-The Fix Team evaluates vulnerability severity on a case-by-case basis, guided by
-CVSS 3.1 and is subject to TC review.
+#### Creating a Temporary Private Fork
 
-## Retrospective
+1. Navigate to the main page of the repository
+2. Click on the "Security" tab
+3. In the left sidebar under "Reporting", click "Advisories"
+4. Select the security advisory you're working on
+5. Scroll to the bottom of the advisory form and click
+  "Start a temporary private fork"
 
-TBD
+The temporary private fork will be created with a name in the format:
+`repo-ghsa-xxxx-xxxx-xxxx`, where `repo` is your repository name (truncated to
+80 characters if needed) and `xxxx-xxxx-xxxx` is the unique identifier of the
+security advisory.
+
+#### Adding Changes to the Fork
+
+You can make changes to the private fork either on GitHub or locally:
+
+- **On GitHub**: Navigate to the temporary private fork from the advisory page,
+  create a new branch, and edit the files as needed
+
+- **Locally**: Clone the temporary private fork, create a branch, make your
+  changes, and push them back to the fork
+
+#### Creating Pull Requests and Merging Changes
+
+1. From the security advisory page, click "Compare & pull request" to create a
+   pull request for your changes
+
+2. When all necessary changes are ready, scroll to the bottom of the advisory
+   page and click "Merge pull request(s)" to merge all open pull requests in the
+   temporary private fork
+
+Important notes about temporary private forks:
+
+- CI/CD integrations do not run in temporary private forks to maintain security
+- You cannot merge individual pull requests; all open PRs are merged together
+- Status checks will not run on PRs in temporary private forks
+- After merging changes, you can publish the advisory to alert the community
+
+For more details, see the [GitHub documentation on private forks](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/collaborating-in-a-temporary-private-fork-to-resolve-a-repository-security-vulnerability).
+
+### Getting Assistance
+
+If Maintainers need assistance with how to handle a security vulnerability:
+
+1. For general guidance of a non sensitive nature, Contact the Security SIG
+  through the #otel-sig-security channel in the Cloud Native Slack workspace.
+  Do not expose sensitive information in this channel as it isn't a secure
+  communication mechanism.
+
+2. For sensitive guidance specific to an Advisory, reach out to Security SIG
+  Maintainers as they have access to all Advisories and can comment directly in
+  them. For complex or high impact issues, the Security SIG may also involve
+  the TC and/or GC.
+
+### CVE Management
+
+#### When to Request a CVE
+
+When determining whether to request a CVE identifier, Maintainers should
+consider the type of OTel deliverables affected (executable vs. library) and the
+source of the vulnerability (direct vs. dependency):
+
+##### For Executables (Collector, Tools, etc.)
+
+1. **Direct Vulnerabilities**: Always request a CVE when a vulnerability exists
+   in OTel's own code that could expose users to security risks.
+
+2. **Dependency Vulnerabilities**: Request a CVE if:
+   - The executable uses the vulnerable part of the dependency
+   - The vulnerability can be exploited through the executable's usage patterns
+   - The vulnerability creates a security impact for users of the executable
+
+   Do not request a CVE if the vulnerability in the dependency cannot be
+   triggered through normal usage of the executable.
+
+   Note that the vulnerability impact for the OTel executable may be different
+   than for the dependency that caused it, depending on how it is used.  Do not
+   assume that the OTel CVE must have the same score as the dependency's CVE.
+
+##### For Libraries
+
+1. **Direct Vulnerabilities**: Request a CVE if the vulnerability exists in
+   OTel's own library code.
+
+2. **Dependency References**: Generally, do not request a CVE when:
+   - The library only references a vulnerable dependency
+   - The dependency is not bundled with the OTel deliverable
+   - The vulnerability only affects consumers who explicitly import both the
+     OTel library and the vulnerable dependency
+
+General criteria for all CVE requests:
+
+1. The vulnerability must affect released versions of OTel
+2. The vulnerability must have security impact (confidentiality, integrity, or
+   availability)
+3. The vulnerability must not already have a CVE assigned to the specific OTel
+   component
+
+#### How to Request a CVE
+
+GitHub provides a streamlined process for requesting CVE identifiers:
+
+1. Within the Security Advisory interface, scroll to the bottom of the form
+2. Click the "Request CVE" button
+3. GitHub will review the request (typically within 72 hours)
+4. Once approved, GitHub will assign a CVE ID to the advisory
+
+If you already have a CVE ID from another CVE Numbering Authority (CNA), you can
+add this to the Security Advisory form instead of requesting a new one through
+GitHub.
+
+For more information on requesting CVEs through GitHub, see the
+[GitHub documentation on requesting CVE identification numbers](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/publishing-a-repository-security-advisory#requesting-a-cve-identification-number-optional).
+
+### FAQ for Maintainers
+
+#### Q: How do I determine the severity of a vulnerability?
+
+**A:** Use the Common Vulnerability Scoring System (CVSS) to assess
+severity. GitHub provides a CVSS calculator in the Security Advisory interface,
+or you can use the [CVSS Calculator](https://www.first.org/cvss/calculator/3.1).
+
+#### Q: Should I fix the vulnerability before publishing the advisory?
+
+**A:** Whenever possible, include a fix version in the advisory before
+publishing. This allows users to update to a secure version immediately upon
+full disclosure. For vulnerabilities that are not publicly known, this is the
+entire point of embargo periods before disclosure.
+
+#### Q: When should I involve the Security SIG or Technical Committee?
+
+**A:** Consider involving them for critical or high-severity issues that can't
+be fixed promptly, vulnerabilities affecting multiple repositories, or if you
+need guidance on handling a security related issue.  If in doubt, feel free
+to reach out.  Just be careful to avoid disclosing non-public vulnerability
+information in non-secure communication channels.
+
+#### Q: How do I handle embargo periods?
+
+**A:** For non-public vulnerabilities, coordinate with the reporter to determine
+if they have a need for public disclosure, for example an upcoming security
+conference at which they want to present. Politely negotiate a timeline for
+disclosure as best you can, but understand that Reporters are under no
+obligation to OTel.  In general, ask that the Reporter not disclose the
+vulnerability beyond the conversation in the Advisory until a fix is made and
+the Advisory has been published.
+
+#### Q: How do I handle a vulnerability that's already public?
+
+**A:** For publicly known vulnerabilities, prioritize creating an advisory and
+releasing a fix as quickly as possible. Note in the advisory that the
+vulnerability is already publicly known. If there is a known work-around or
+mitigation that users can implement, consider publishing an advisory with the
+work-around info until a fix can be made. This option should be balanced with
+how useful the work-around would be to users vs further advertising the
+vulnerability. If a vulnerability is so well known that multiple reports are
+being made, it can be advantageous to publish to avoid the reporting noise.
+
+#### Q: What do I do if a private vulnerability becomes public?
+
+**A:** Similar to a reported vulnerability that was already publicly known:
+Continue your efforts to fix the vulnerability with urgency appropriate to its
+severity.  Document the change in status in the Advisory so that the
+Collaborators and Reporter are aware that the vulnerability is openly known.
+However, continue to avoid spreading information about the
+vulnerability unless it significantly helps with the speed of the fix or
+users need to be informed of a work-around or mitigation steps.
+
+#### Q: What if we can't fix the vulnerability quickly?
+
+**A:** If a fix will take a long time, particularly if the vulnerability is high
+or critical severity, you should bring this up with the Security SIG and/or TC
+to determine if there is any public messaging or other actions that need to be
+taken.


### PR DESCRIPTION
Second part of the updates to the Vulnerability Management documentation.
This is a rewrite of the policies around how maintainers should handle vulnerabilities to match both actual practices and bring consistency to them.