### PR TITLE
Add Trask as an approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 - [Adriel Perkins](https://github.com/adrielp), Liatrio
+- [Trask Stalnaker](https://github.com/trask), Microsoft
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 


### PR DESCRIPTION
Follow up https://github.com/open-telemetry/sig-security/pull/150#issuecomment-3099783827.

Trask has done lots of contributions to the overall OpenTelemetry security, and has demonstrated good judgement and security mindset. He is currently the 2nd most active contributor to the Security SIG in terms of the number of PRs https://github.com/open-telemetry/sig-security/issues?q=is%3Apr%20author%3Atrask.

Following the process https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver, I would like to nominate Trask as an approver.

@ms-jcorley FYI.