### PR TITLE
Fix CVE data source workflow

### DIFF
--- a/.github/workflows/update-cve-data.yml
+++ b/.github/workflows/update-cve-data.yml
@@ -1,0 +1,47 @@
+name: Update CVE Data
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # run once a day
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout main branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: setup python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: install python packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tools/update-cve-data-requirements.txt
+
+      - name: execute python script
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+        run: python tools/update-cve-data.py /tmp/published_output.json
+
+      - name: push data to data-source branch
+        run: |
+          git fetch origin data-source
+          git checkout data-source
+          cp /tmp/published_output.json .
+          git add published_output.json
+
+          if ! git diff --cached --quiet; then
+            git config user.name otelbot
+            git config user.email 197425009+otelbot@users.noreply.github.com
+            git commit -m "Update CVE data"
+            git push origin data-source
+          fi

--- a/tools/update-cve-data-requirements.txt
+++ b/tools/update-cve-data-requirements.txt
@@ -1,0 +1,3 @@
+pandas>=2.0.0
+requests>=2.31.0
+pytz>=2024.1

--- a/tools/update-cve-data.py
+++ b/tools/update-cve-data.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+import pandas as pd
+import requests
+
+parser = argparse.ArgumentParser()
+parser.add_argument('output_file', help='Path to output JSON file')
+args = parser.parse_args()
+
+token = os.environ['GITHUB_TOKEN']
+
+# Define the URL for the GitHub Security Advisories API
+url = "https://api.github.com/orgs/open-telemetry/security-advisories"
+
+# Set up the request headers with the authorization token
+headers = {
+    'Accept': "application/vnd.github+json",
+    'Authorization': f"Bearer {token}",
+    'X-GitHub-Api-Version': "2022-11-28"
+}
+
+# Initialize an empty list to store responses
+responses = []
+
+try:
+    # Send a GET request to the GitHub API
+    response = requests.get(url, headers=headers)
+
+    # Check if the request was successful (status code 200)
+    if response.status_code == 200:
+        advisories = response.json()
+        # Now, 'advisories' contains the security advisories data.
+        # Append the response data to the 'responses' list
+        responses.append(advisories)
+        print(advisories)
+    else:
+        print(f"Request failed with status code {response.status_code}")
+        print(response.text)
+except Exception as e:
+    print(f"An error occurred: {e}")
+
+for idx, advisory_response in enumerate(responses, 1):
+    print(f"Response {idx}:")
+    print(advisory_response)
+
+# Extract specified fields and create a DataFrame
+data = {
+    'ghsa_id': [item["ghsa_id"] for item in advisory_response],
+    'cve_id': [item["cve_id"] for item in advisory_response],
+    'html_url': [item["html_url"] for item in advisory_response],
+    'summary': [item["summary"] for item in advisory_response],
+    'severity': [item["severity"] for item in advisory_response],
+    'state': [item["state"] for item in advisory_response],
+    'created_at': [item["created_at"] for item in advisory_response],
+    'updated_at': [item["updated_at"] for item in advisory_response]
+}
+df = pd.DataFrame(data)
+
+# Split the repository name from the url and add it as a new column 'repo'
+df['repo'] = df['html_url'].str.split('/').str[4]
+
+# Filter rows where the 'text' column contains either 'test' or 'testing'
+filtered_df = df[~df['summary'].str.contains('test only', case=False, regex=True)]
+
+df_filled = filtered_df.fillna('na')
+
+## Filter for published information
+filtered_json = df_filled[df_filled['state'] == 'published']
+
+# Write DataFrame to JSON file for published incidents
+filtered_json.to_json(args.output_file, orient='records')


### PR DESCRIPTION
Fixes #188 

The problem is that the workflow was on the `data-source` branch itself, and scheduled workflows only run from `main`.

The fix is to move everything to `main` branch and only store the [published_output.json](https://github.com/open-telemetry/sig-security/blob/data-source/published_output.json) on the `data-source` branch.

One things are working again, I will clean up the `data-source` branch so that it only has this one file.