### PR TITLE
Reduce permissions needed to run CVE data source workflow

### DIFF
--- a/.github/workflows/update-cve-data.yml
+++ b/.github/workflows/update-cve-data.yml
@@ -28,8 +28,6 @@ jobs:
           pip install -r tools/update-cve-data-requirements.txt
 
       - name: execute python script
-        env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: python tools/update-cve-data.py /tmp/published_output.json
 
       - name: push data to data-source branch

--- a/tools/update-cve-data-requirements.txt
+++ b/tools/update-cve-data-requirements.txt
@@ -1,3 +1,1 @@
-pandas>=2.0.0
 requests>=2.31.0
-pytz>=2024.1

--- a/tools/update-cve-data.py
+++ b/tools/update-cve-data.py
@@ -1,71 +1,65 @@
 import argparse
-import os
-import pandas as pd
+import json
+import sys
 import requests
+
+# This script fetches published security advisories by iterating over all repos
+# in the open-telemetry org. This approach is slower than using the org-level
+# security advisories endpoint, but does not require elevated permissions that
+# would also grant access to draft (unpublished) advisories.
 
 parser = argparse.ArgumentParser()
 parser.add_argument('output_file', help='Path to output JSON file')
 args = parser.parse_args()
 
-token = os.environ['GITHUB_TOKEN']
-
-# Define the URL for the GitHub Security Advisories API
-url = "https://api.github.com/orgs/open-telemetry/security-advisories"
-
-# Set up the request headers with the authorization token
 headers = {
-    'Accept': "application/vnd.github+json",
-    'Authorization': f"Bearer {token}",
-    'X-GitHub-Api-Version': "2022-11-28"
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28'
 }
 
-# Initialize an empty list to store responses
-responses = []
-
-try:
-    # Send a GET request to the GitHub API
+# Get all public repos in the open-telemetry org
+repos = []
+url = 'https://api.github.com/orgs/open-telemetry/repos?per_page=100&type=public'
+while url:
     response = requests.get(url, headers=headers)
-
-    # Check if the request was successful (status code 200)
-    if response.status_code == 200:
-        advisories = response.json()
-        # Now, 'advisories' contains the security advisories data.
-        # Append the response data to the 'responses' list
-        responses.append(advisories)
-        print(advisories)
-    else:
-        print(f"Request failed with status code {response.status_code}")
+    if response.status_code != 200:
+        print(f'Failed to fetch repos: {response.status_code}')
         print(response.text)
-except Exception as e:
-    print(f"An error occurred: {e}")
+        sys.exit(1)
+    repos.extend(response.json())
+    url = response.links.get('next', {}).get('url')
 
-for idx, advisory_response in enumerate(responses, 1):
-    print(f"Response {idx}:")
-    print(advisory_response)
+# Fetch published security advisories for each repo
+advisories = []
+for repo in repos:
+    repo_name = repo['name']
+    url = f'https://api.github.com/repos/open-telemetry/{repo_name}/security-advisories?state=published'
+    response = requests.get(url, headers=headers)
+    if response.status_code != 200:
+        print(f'Failed to fetch advisories for {repo_name}: {response.status_code}')
+        print(response.text)
+        sys.exit(1)
+    repo_advisories = response.json()
+    if repo_advisories:
+        advisories.extend(repo_advisories)
 
-# Extract specified fields and create a DataFrame
-data = {
-    'ghsa_id': [item["ghsa_id"] for item in advisory_response],
-    'cve_id': [item["cve_id"] for item in advisory_response],
-    'html_url': [item["html_url"] for item in advisory_response],
-    'summary': [item["summary"] for item in advisory_response],
-    'severity': [item["severity"] for item in advisory_response],
-    'state': [item["state"] for item in advisory_response],
-    'created_at': [item["created_at"] for item in advisory_response],
-    'updated_at': [item["updated_at"] for item in advisory_response]
-}
-df = pd.DataFrame(data)
+# Extract fields and filter out test advisories
+output = []
+for item in advisories:
+    summary = item.get('summary', '')
+    if 'test only' in summary.lower():
+        continue
+    output.append({
+        'ghsa_id': item.get('ghsa_id'),
+        'cve_id': item.get('cve_id') or 'na',
+        'html_url': item.get('html_url'),
+        'summary': summary,
+        'severity': item.get('severity'),
+        'state': item.get('state'),
+        'created_at': item.get('created_at') or 'na',
+        'updated_at': item.get('updated_at') or 'na',
+        'repo': item.get('html_url', '').split('/')[4] if item.get('html_url') else 'na'
+    })
 
-# Split the repository name from the url and add it as a new column 'repo'
-df['repo'] = df['html_url'].str.split('/').str[4]
-
-# Filter rows where the 'text' column contains either 'test' or 'testing'
-filtered_df = df[~df['summary'].str.contains('test only', case=False, regex=True)]
-
-df_filled = filtered_df.fillna('na')
-
-## Filter for published information
-filtered_json = df_filled[df_filled['state'] == 'published']
-
-# Write DataFrame to JSON file for published incidents
-filtered_json.to_json(args.output_file, orient='records')
+with open(args.output_file, 'w') as f:
+    json.dump(output, f)


### PR DESCRIPTION
In my first attempt (#189), I used `OPENTELEMETRYBOT_GITHUB_TOKEN` to try to access the org security advisories API, thinking it was enough to get public advisories, but it doesn't have access b/c _any_ access to that API gives you access to draft (unpublished) advisories.