### PR TITLE
CVE data source workflow needs higher API rate limit

### DIFF
--- a/.github/workflows/update-cve-data.yml
+++ b/.github/workflows/update-cve-data.yml
@@ -28,6 +28,9 @@ jobs:
           pip install -r tools/update-cve-data-requirements.txt
 
       - name: execute python script
+        env:
+          # this is only needed here for higher API rate limits
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python tools/update-cve-data.py /tmp/published_output.json
 
       - name: push data to data-source branch

--- a/tools/update-cve-data.py
+++ b/tools/update-cve-data.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import sys
 import requests
 
@@ -16,6 +17,11 @@ headers = {
     'Accept': 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28'
 }
+
+# Use GITHUB_TOKEN if available for higher rate limits
+token = os.environ.get('GITHUB_TOKEN')
+if token:
+    headers['Authorization'] = f'Bearer {token}'
 
 # Get all public repos in the open-telemetry org
 repos = []


### PR DESCRIPTION
Latest failure: https://github.com/open-telemetry/sig-security/actions/runs/19834724738/job/56829112734