### PR TITLE
Pin python dependencies

### DIFF
--- a/tools/update-cve-data-requirements.txt
+++ b/tools/update-cve-data-requirements.txt
@@ -1,1 +1,2 @@
-requests>=2.31.0
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f


### PR DESCRIPTION
Intentionally pinning to older version to verify that Renovate update is working after merging