### PR TITLE
add recommendations for GitHub immutable releases

### DIFF
--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -26,9 +26,8 @@ a permanent, verifiable record.
 
 Best practices:
 
-- Create releases as **drafts first**, attach all intended assets, and only then
-  publish. Creating a draft release first allows you to attach all assets before
-  the release becomes immutable.
+- Consider creating releases as **drafts first**. This allows you to attach all
+  assets before the release becomes immutable.
 - Prefer a fully automated, reproducible release process (CI builds artifacts
   from a tagged commit, then publishes the release). Avoid building artifacts on
   developer workstations.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/sig-security/issues/164

This is already used in several repositories such as (and not limited to):
- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/tag/v0.4.1
- https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.14.0
- https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.39.0
- https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.15.0