### PR TITLE
Add section for security model to security response guidelines

### DIFF
--- a/security-response.md
+++ b/security-response.md
@@ -28,9 +28,10 @@ When assessing the urgency and importance of a security fix, confidentiality and
 integrity are our topmost concerns for all OpenTelemetry software artifacts.
 
 In contrast, we do not consider the default settings of OpenTelemetry software
-artifacts to be secure against availability attacks. To ensure availability,
-users must require authentication for their endpoint communication following the
-guidance on the [Security section of our
+artifacts to be secure against availability attacks. We highly recommend not
+using insecure defaults where feasible. To ensure availability, users must
+require authentication for their endpoint communication following the guidance
+on the [Security section of our
 website](https://opentelemetry.io/docs/security/).
 
 Additionally, the OpenTelemetry project does not consider the following to be
@@ -41,9 +42,10 @@ security vulnerabilities:
 
 These may still be considered bugs, and users can report them as such. When
 assessing availability-related impact, maintainers will also take into account
-whether the affected functionality comes from a dependency that is not protected
-against these attacks as well as the level of asymmetry in terms of resource
-usage leveraged by the attack.
+the security policies of other projects (e.g. Prometheus) when assessing
+vulnerabilities against components that provide compatibility with those
+projects, as well as the level of asymmetry in terms of resource usage leveraged
+by the attack.
 
 ## Reporting Process - For Vulnerability Reporters
 

--- a/security-response.md
+++ b/security-response.md
@@ -22,6 +22,19 @@ be released. Each repository is entitled to establish their own complementary
 processes. SIG-Security in conjunction with the TC can advise in case
 clarifications are required.
 
+## Security model
+
+When assessing the urgency and importance of a security fix, confidentiality and integrity are our topmost concerns for all OpenTelemetry software artifacts.
+
+In contrast, we do not consider the default settings of OpenTelemetry software artifacts to be secure against availability attacks. To ensure availability, users must require authentication for their endpoint communication following the guidance on the [Security section of our website](https://opentelemetry.io/docs/security/).
+
+Additionally, the OpenTelemetry project does not consider the following to be security vulnerabilities:
+
+- a denial of service attack by properly authenticated clients  
+- availability-related attack to endpoints by properly authenticated clients
+
+These may still be considered bugs, and users can report them as such. When assessing availability-related impact, maintainers will also take into account whether the affected functionality comes from a dependency that is not protected against these attacks as well as the level of asymmetry in terms of resource usage leveraged by the attack.
+
 ## Reporting Process - For Vulnerability Reporters
 
 ### Reporting Methods

--- a/security-response.md
+++ b/security-response.md
@@ -24,16 +24,26 @@ clarifications are required.
 
 ## Security model
 
-When assessing the urgency and importance of a security fix, confidentiality and integrity are our topmost concerns for all OpenTelemetry software artifacts.
+When assessing the urgency and importance of a security fix, confidentiality and
+integrity are our topmost concerns for all OpenTelemetry software artifacts.
 
-In contrast, we do not consider the default settings of OpenTelemetry software artifacts to be secure against availability attacks. To ensure availability, users must require authentication for their endpoint communication following the guidance on the [Security section of our website](https://opentelemetry.io/docs/security/).
+In contrast, we do not consider the default settings of OpenTelemetry software
+artifacts to be secure against availability attacks. To ensure availability,
+users must require authentication for their endpoint communication following the
+guidance on the [Security section of our
+website](https://opentelemetry.io/docs/security/).
 
-Additionally, the OpenTelemetry project does not consider the following to be security vulnerabilities:
+Additionally, the OpenTelemetry project does not consider the following to be
+security vulnerabilities:
 
-- a denial of service attack by properly authenticated clients  
+- a denial of service attack by properly authenticated clients
 - availability-related attack to endpoints by properly authenticated clients
 
-These may still be considered bugs, and users can report them as such. When assessing availability-related impact, maintainers will also take into account whether the affected functionality comes from a dependency that is not protected against these attacks as well as the level of asymmetry in terms of resource usage leveraged by the attack.
+These may still be considered bugs, and users can report them as such. When
+assessing availability-related impact, maintainers will also take into account
+whether the affected functionality comes from a dependency that is not protected
+against these attacks as well as the level of asymmetry in terms of resource
+usage leveraged by the attack.
 
 ## Reporting Process - For Vulnerability Reporters
 


### PR DESCRIPTION
Adds a section to security response guidelines about our security model. This security model attempts to clarify when we will request a CVE for vulnerabilities reported to us, and what expectations should end-users and security reporters have when it comes to availability-related guarantees for OpenTelemetry software artifacts.

This is heavily inspired by the security/threat models of other CNCF and open source projects which have similar stances:
- PostgreSQL's [*What is a Security Vulnerability in PostgreSQL?*](https://www.postgresql.org/support/security/):
> The PostgreSQL Security Team typically does not consider a denial-of-service on a PostgreSQL server from an authenticated, valid SQL statement to be a security vulnerability
- Prometheus' [*Security Model*](https://prometheus.io/docs/operating/security/):
> the HTTP endpoints provided by Prometheus components should not be exposed to publicly accessible networks like the internet [...], it is easily possible to overload and ultimately DoS servers with requests to these endpoints.
- Envoy's [*Threat Model*](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/threat_model#confidentiality-integrity-and-availability):
> Note that we do not currently consider the default settings for Envoy to be safe from an availability perspective. 

cc @open-telemetry/technical-committee @open-telemetry/collector-contrib-approvers @open-telemetry/sig-security-approvers 