### PR TITLE
Configure security-only Dependabot updates

### DIFF
--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -1,0 +1,41 @@
+# Dependency update tooling
+
+This repository uses both Renovate and Dependabot, with strictly separated
+responsibilities. Do not enable a feature in one tool that the other already
+owns.
+
+## Split of responsibilities
+
+| Concern | Tool |
+| --- | --- |
+| Routine Python dependency updates | Renovate |
+| `pip-compile` output refreshes | Renovate |
+| GitHub Actions updates | Renovate |
+| Alert-driven direct dependency security updates | Dependabot |
+| Alert-driven transitive dependency security updates | Dependabot |
+
+Configuration files:
+
+- [renovate.json5](renovate.json5)
+- [dependabot.yml](dependabot.yml)
+
+## Why the split
+
+Renovate owns routine maintenance. It updates the direct Python requirements,
+refreshes the compiled requirements file and its hashes, and keeps GitHub
+Actions pinned to full commit hashes.
+
+Dependabot complements Renovate with updates driven by GitHub security alerts.
+GitHub's dependency graph includes the resolved dependencies from
+`tools/update-cve-data-requirements.txt` and the actions referenced by the
+repository's workflows, so Dependabot can evaluate both direct and transitive
+dependencies. `open-pull-requests-limit: 0` disables routine Dependabot pull
+requests without disabling security updates.
+
+Dependabot can create an update only when GitHub has an applicable alert and can
+determine an available remediation. Alerts that cannot be remediated
+automatically still require maintainer investigation.
+
+GitHub does not apply Dependabot cooldown settings to security updates. The
+cooldown values in [dependabot.yml](dependabot.yml) satisfy zizmor and would take
+effect only if routine Dependabot updates were enabled in the future.

--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -11,6 +11,7 @@ owns.
 | Routine Python dependency updates | Renovate |
 | `pip-compile` output refreshes | Renovate |
 | GitHub Actions updates | Renovate |
+| Alert-driven GitHub Actions security updates | Dependabot |
 | Alert-driven direct dependency security updates | Dependabot |
 | Alert-driven transitive dependency security updates | Dependabot |
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# See DEPENDENCIES.md for how Renovate and Dependabot responsibilities are separated.
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /tools
+    schedule:
+      interval: weekly
+    # Cooldown does not apply to security updates; this value satisfies zizmor.
+    cooldown:
+      default-days: 7
+    # Disable routine update PRs; security update PRs use a separate limit.
+    open-pull-requests-limit: 0
+    groups:
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # Cooldown does not apply to security updates; this value satisfies zizmor.
+    cooldown:
+      default-days: 7
+    # Disable routine update PRs; security update PRs use a separate limit.
+    open-pull-requests-limit: 0
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Renovate handles routine dependency updates, but its OSV vulnerability alerts cover only direct dependencies, and Renovate does not target transitive dependencies for updates. Add Dependabot for alert-driven security updates to Python dependencies and GitHub Actions, while leaving routine updates with Renovate to avoid duplicate PRs.

Document how the two tools work together. This follows the approach already used by [semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/.github/DEPENDENCIES.md).

Relates to #91.